### PR TITLE
fix: AnimatedFlowLinesLayer rendering issue

### DIFF
--- a/packages/layers/src/AnimatedFlowLinesLayer/AnimatedFlowLinesLayer.ts
+++ b/packages/layers/src/AnimatedFlowLinesLayer/AnimatedFlowLinesLayer.ts
@@ -95,11 +95,15 @@ export default class AnimatedFlowLinesLayer<F> extends Layer {
     attributeManager.addInstanced({
       instanceSourcePositions: {
         size: 3,
+        type: GL.DOUBLE,
+        fp64: this.use64bitPositions(),
         transition: true,
         accessor: 'getSourcePosition',
       },
       instanceTargetPositions: {
         size: 3,
+        type: GL.DOUBLE,
+        fp64: this.use64bitPositions(),
         transition: true,
         accessor: 'getTargetPosition',
       },


### PR DESCRIPTION
- repro steps: run react-app, enable animation, zoom in, hover any circle

So strange that the issue only happened after hovering over any circle, and stayed after that.

![Screen Shot 2022-02-15 at 5 20 30 PM](https://user-images.githubusercontent.com/8210766/154096455-59e90ded-f3b6-4626-842d-6fb927302400.png)
