### PR TITLE
Add configurable viewport endpoint culling for FlowmapLayer

### DIFF
--- a/docs/docs/api/flowmap-layer.md
+++ b/docs/docs/api/flowmap-layer.md
@@ -195,6 +195,17 @@ Whether to adapt flow thickness and color scales to the current viewport. When `
 
 Maximum number of flows to display. Flows are sorted by magnitude and only the top N are shown. Increase for denser visualizations (may impact performance).
 
+#### `flowEndpointsInViewportMode`
+
+- Type: `'any' | 'both'`
+- Default: `'any'`
+
+Controls when a flow is considered visible based on endpoint locations:
+- `'any'`: Show flows if at least one endpoint (origin OR destination) is in viewport
+- `'both'`: Show flows only if both endpoints (origin AND destination) are in viewport
+
+The `'both'` mode is useful for stricter local views where you only want to see flows fully contained in the visible area.
+
 ### Event Handlers
 
 #### `onHover`

--- a/examples/common/src/ui-config.js
+++ b/examples/common/src/ui-config.js
@@ -25,6 +25,8 @@ export const UI_INITIAL = {
   locationTotalsEnabled: FlowmapLayer.defaultProps.locationTotalsEnabled,
   locationLabelsEnabled: FlowmapLayer.defaultProps.locationLabelsEnabled,
   maxTopFlowsDisplayNum: FlowmapLayer.defaultProps.maxTopFlowsDisplayNum,
+  flowEndpointsInViewportMode:
+    FlowmapLayer.defaultProps.flowEndpointsInViewportMode,
 };
 
 export const initLilGui = (gui) => {
@@ -36,6 +38,7 @@ export const initLilGui = (gui) => {
   gui.add(UI_INITIAL, 'locationsEnabled');
   gui.add(UI_INITIAL, 'locationTotalsEnabled');
   gui.add(UI_INITIAL, 'locationLabelsEnabled');
+  gui.add(UI_INITIAL, 'flowEndpointsInViewportMode', ['any', 'both']);
 
   gui
     .add(UI_INITIAL, 'maxTopFlowsDisplayNum')

--- a/examples/react-app/src/App.tsx
+++ b/examples/react-app/src/App.tsx
@@ -88,6 +88,7 @@ function App() {
         adaptiveScalesEnabled: config.adaptiveScalesEnabled,
         highlightColor: config.highlightColor,
         maxTopFlowsDisplayNum: config.maxTopFlowsDisplayNum,
+        flowEndpointsInViewportMode: config.flowEndpointsInViewportMode,
         getLocationId: (loc) => loc.id,
         getLocationLat: (loc) => loc.lat,
         getLocationLon: (loc) => loc.lon,

--- a/packages/data/src/FlowmapSelectors.ts
+++ b/packages/data/src/FlowmapSelectors.ts
@@ -101,6 +101,10 @@ export default class FlowmapSelectors<
   };
   getMaxTopFlowsDisplayNum = (state: FlowmapState, props: FlowmapData<L, F>) =>
     state.settings.maxTopFlowsDisplayNum;
+  getFlowEndpointsInViewportMode = (
+    state: FlowmapState,
+    props: FlowmapData<L, F>,
+  ) => state.settings.flowEndpointsInViewportMode;
   getSelectedLocations = (state: FlowmapState, props: FlowmapData<L, F>) =>
     state.filter?.selectedLocations;
   getLocationFilterMode = (state: FlowmapState, props: FlowmapData<L, F>) =>
@@ -847,12 +851,14 @@ export default class FlowmapSelectors<
       this.getSelectedLocationsSet,
       this.getLocationFilterMode,
       this.getMaxTopFlowsDisplayNum,
+      this.getFlowEndpointsInViewportMode,
       (
         flows,
         locationIdsInViewport,
         selectedLocationsSet,
         locationFilterMode,
         maxTopFlowsDisplayNum,
+        flowEndpointsInViewportMode,
       ) => {
         if (!flows || !locationIdsInViewport) return undefined;
         const picked: (F | AggregateFlow)[] = [];
@@ -860,10 +866,13 @@ export default class FlowmapSelectors<
         for (const flow of flows) {
           const origin = this.accessors.getFlowOriginId(flow);
           const dest = this.accessors.getFlowDestId(flow);
-          if (
-            locationIdsInViewport.has(origin) ||
-            locationIdsInViewport.has(dest)
-          ) {
+          const originInView = locationIdsInViewport.has(origin);
+          const destInView = locationIdsInViewport.has(dest);
+          const isInViewport =
+            flowEndpointsInViewportMode === 'both'
+              ? originInView && destInView
+              : originInView || destInView;
+          if (isInViewport) {
             if (
               this.isFlowInSelection(
                 flow,

--- a/packages/data/src/FlowmapState.ts
+++ b/packages/data/src/FlowmapState.ts
@@ -6,6 +6,8 @@
 
 import {LocationFilterMode, ViewportProps} from './types';
 
+export type FlowEndpointsInViewportMode = 'any' | 'both';
+
 export interface FilterState {
   selectedLocations?: (string | number)[];
   locationFilterMode?: LocationFilterMode;
@@ -28,6 +30,7 @@ export interface SettingsState {
   colorScheme: string | string[] | undefined;
   highlightColor: string;
   maxTopFlowsDisplayNum: number;
+  flowEndpointsInViewportMode: FlowEndpointsInViewportMode;
 }
 
 export interface FlowmapState {

--- a/packages/layers/src/FlowmapLayer.ts
+++ b/packages/layers/src/FlowmapLayer.ts
@@ -7,6 +7,7 @@ import {CompositeLayer} from '@deck.gl/core';
 import {ScatterplotLayer, TextLayer} from '@deck.gl/layers';
 import {
   FilterState,
+  FlowEndpointsInViewportMode,
   FlowLinesLayerAttributes,
   FlowmapAggregateAccessors,
   FlowmapData,
@@ -55,6 +56,7 @@ export type FlowmapLayerProps<
   colorScheme?: string | string[];
   highlightColor?: string | number[];
   maxTopFlowsDisplayNum?: number;
+  flowEndpointsInViewportMode?: FlowEndpointsInViewportMode;
   onHover?: (
     info: FlowmapLayerPickingInfo<L, F> | undefined,
     event: SourceEvent,
@@ -80,6 +82,7 @@ const PROPS_TO_CAUSE_LAYER_DATA_UPDATE: string[] = [
   'colorScheme',
   'highlightColor',
   'maxTopFlowsDisplayNum',
+  'flowEndpointsInViewportMode',
 ];
 
 enum HighlightType {
@@ -132,6 +135,7 @@ export default class FlowmapLayer<
     colorScheme: 'Teal',
     highlightColor: 'orange',
     maxTopFlowsDisplayNum: 5000,
+    flowEndpointsInViewportMode: 'any',
   };
   state: State<L, F> | undefined;
 
@@ -288,6 +292,7 @@ export default class FlowmapLayer<
       colorScheme,
       highlightColor,
       maxTopFlowsDisplayNum,
+      flowEndpointsInViewportMode,
     } = this.props;
     return {
       locationsEnabled,
@@ -305,6 +310,7 @@ export default class FlowmapLayer<
       colorScheme,
       highlightColor,
       maxTopFlowsDisplayNum,
+      flowEndpointsInViewportMode,
     };
   }
 


### PR DESCRIPTION
## Summary

This PR adds a new `flowEndpointsInViewportMode` prop to `FlowmapLayer` that gives users control over how flows are filtered based on viewport visibility.

<img width="3508" height="1978" alt="Google Chrome 2026-02-06 09 28 13" src="https://github.com/user-attachments/assets/742d1f76-428a-4eb4-9db8-dc6c66049729" />
<img width="3508" height="1978" alt="Google Chrome 2026-02-06 09 28 18" src="https://github.com/user-attachments/assets/87e824d6-e737-4405-88b8-14cca86aa77a" />


## Problem

Currently, a flow is rendered if **at least one** of its endpoints (origin or destination) is within the current viewport. This means flows with one endpoint far outside the viewport can still appear, which may not be desirable for use cases requiring a strict "local window" view.

## Solution

Added a new optional prop `flowEndpointsInViewportMode` with two modes:

| Mode | Behavior |
|------|----------|
| `'any'` (default) | Show flow if origin **OR** destination is in viewport |
| `'both'` | Show flow only if origin **AND** destination are both in viewport |

The default `'any'` preserves backward compatibility with existing behavior.

## Changes

### Core Implementation

| File | Changes |
|------|---------|
| `packages/data/src/FlowmapState.ts` | Added `FlowEndpointsInViewportMode` type and field to `SettingsState` |
| `packages/data/src/FlowmapSelectors.ts` | Added selector accessor and updated `getFlowsForFlowmapLayer` with conditional AND/OR logic |
| `packages/layers/src/FlowmapLayer.ts` | Added prop to interface, defaults, update triggers, and settings state serialization |

### Example App

| File | Changes |
|------|---------|
| `examples/common/src/ui-config.js` | Added to `UI_INITIAL` and dropdown control |
| `examples/react-app/src/App.tsx` | Pass prop to `FlowmapLayer` |

### Documentation

| File | Changes |
|------|---------|
| `docs/docs/api/flowmap-layer.md` | Added prop documentation under Performance section |

## Usage

```tsx
<FlowmapLayer
  // ... other props
  flowEndpointsInViewportMode="both"  // Only show flows fully contained in viewport
/>
```

## Testing

- ✅ TypeScript compilation passes for both `@flowmap.gl/data` and `@flowmap.gl/layers`
- ✅ Manual testing with example app (dropdown in GUI panel)

### Manual Testing Steps

1. Run `yarn dev`
2. Open http://localhost:5173
3. Toggle the `flowEndpointsInViewportMode` dropdown while panning the map
4. In `'both'` mode, flows should disappear when either endpoint leaves the viewport