### PR TITLE
Add `flowEndpointsInViewportMode` prop for configurable viewport cull…

### DIFF
--- a/docs/docs/api/flowmap-layer.md
+++ b/docs/docs/api/flowmap-layer.md
@@ -195,6 +195,17 @@ Whether to adapt flow thickness and color scales to the current viewport. When `
 
 Maximum number of flows to display. Flows are sorted by magnitude and only the top N are shown. Increase for denser visualizations (may impact performance).
 
+#### `flowEndpointsInViewportMode`
+
+- Type: `'any' | 'both'`
+- Default: `'any'`
+
+Controls when a flow is considered visible based on endpoint locations:
+- `'any'`: Show flows if at least one endpoint (origin OR destination) is in viewport
+- `'both'`: Show flows only if both endpoints (origin AND destination) are in viewport
+
+The `'both'` mode is useful for stricter local views where you only want to see flows fully contained in the visible area.
+
 ### Event Handlers
 
 #### `onHover`

--- a/examples/common/src/ui-config.js
+++ b/examples/common/src/ui-config.js
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {FlowmapLayer} from '@flowmap.gl/layers';
 import {COLOR_SCHEMES} from '@flowmap.gl/data';
+import {FlowmapLayer} from '@flowmap.gl/layers';
 
 export const UI_INITIAL = {
   darkMode: true,
@@ -25,8 +25,7 @@ export const UI_INITIAL = {
   locationTotalsEnabled: FlowmapLayer.defaultProps.locationTotalsEnabled,
   locationLabelsEnabled: FlowmapLayer.defaultProps.locationLabelsEnabled,
   maxTopFlowsDisplayNum: FlowmapLayer.defaultProps.maxTopFlowsDisplayNum,
-  flowEndpointsInViewportMode:
-    FlowmapLayer.defaultProps.flowEndpointsInViewportMode,
+  flowEndpointsInViewportMode: 'any',
 };
 
 export const initLilGui = (gui) => {

--- a/examples/common/src/ui-config.js
+++ b/examples/common/src/ui-config.js
@@ -25,6 +25,8 @@ export const UI_INITIAL = {
   locationTotalsEnabled: FlowmapLayer.defaultProps.locationTotalsEnabled,
   locationLabelsEnabled: FlowmapLayer.defaultProps.locationLabelsEnabled,
   maxTopFlowsDisplayNum: FlowmapLayer.defaultProps.maxTopFlowsDisplayNum,
+  flowEndpointsInViewportMode:
+    FlowmapLayer.defaultProps.flowEndpointsInViewportMode,
 };
 
 export const initLilGui = (gui) => {
@@ -36,6 +38,7 @@ export const initLilGui = (gui) => {
   gui.add(UI_INITIAL, 'locationsEnabled');
   gui.add(UI_INITIAL, 'locationTotalsEnabled');
   gui.add(UI_INITIAL, 'locationLabelsEnabled');
+  gui.add(UI_INITIAL, 'flowEndpointsInViewportMode', ['any', 'both']);
 
   gui
     .add(UI_INITIAL, 'maxTopFlowsDisplayNum')

--- a/examples/react-app/src/App.tsx
+++ b/examples/react-app/src/App.tsx
@@ -88,6 +88,7 @@ function App() {
         adaptiveScalesEnabled: config.adaptiveScalesEnabled,
         highlightColor: config.highlightColor,
         maxTopFlowsDisplayNum: config.maxTopFlowsDisplayNum,
+        flowEndpointsInViewportMode: config.flowEndpointsInViewportMode,
         getLocationId: (loc) => loc.id,
         getLocationLat: (loc) => loc.lat,
         getLocationLon: (loc) => loc.lon,

--- a/packages/data/src/FlowmapSelectors.ts
+++ b/packages/data/src/FlowmapSelectors.ts
@@ -101,6 +101,10 @@ export default class FlowmapSelectors<
   };
   getMaxTopFlowsDisplayNum = (state: FlowmapState, props: FlowmapData<L, F>) =>
     state.settings.maxTopFlowsDisplayNum;
+  getFlowEndpointsInViewportMode = (
+    state: FlowmapState,
+    props: FlowmapData<L, F>,
+  ) => state.settings.flowEndpointsInViewportMode;
   getSelectedLocations = (state: FlowmapState, props: FlowmapData<L, F>) =>
     state.filter?.selectedLocations;
   getLocationFilterMode = (state: FlowmapState, props: FlowmapData<L, F>) =>
@@ -847,12 +851,14 @@ export default class FlowmapSelectors<
       this.getSelectedLocationsSet,
       this.getLocationFilterMode,
       this.getMaxTopFlowsDisplayNum,
+      this.getFlowEndpointsInViewportMode,
       (
         flows,
         locationIdsInViewport,
         selectedLocationsSet,
         locationFilterMode,
         maxTopFlowsDisplayNum,
+        flowEndpointsInViewportMode,
       ) => {
         if (!flows || !locationIdsInViewport) return undefined;
         const picked: (F | AggregateFlow)[] = [];
@@ -860,10 +866,13 @@ export default class FlowmapSelectors<
         for (const flow of flows) {
           const origin = this.accessors.getFlowOriginId(flow);
           const dest = this.accessors.getFlowDestId(flow);
-          if (
-            locationIdsInViewport.has(origin) ||
-            locationIdsInViewport.has(dest)
-          ) {
+          const originInView = locationIdsInViewport.has(origin);
+          const destInView = locationIdsInViewport.has(dest);
+          const isInViewport =
+            flowEndpointsInViewportMode === 'both'
+              ? originInView && destInView
+              : originInView || destInView;
+          if (isInViewport) {
             if (
               this.isFlowInSelection(
                 flow,

--- a/packages/data/src/FlowmapState.ts
+++ b/packages/data/src/FlowmapState.ts
@@ -6,6 +6,8 @@
 
 import {LocationFilterMode, ViewportProps} from './types';
 
+export type FlowEndpointsInViewportMode = 'any' | 'both';
+
 export interface FilterState {
   selectedLocations?: (string | number)[];
   locationFilterMode?: LocationFilterMode;
@@ -28,6 +30,7 @@ export interface SettingsState {
   colorScheme: string | string[] | undefined;
   highlightColor: string;
   maxTopFlowsDisplayNum: number;
+  flowEndpointsInViewportMode: FlowEndpointsInViewportMode;
 }
 
 export interface FlowmapState {

--- a/packages/layers/package.json
+++ b/packages/layers/package.json
@@ -14,7 +14,7 @@
     "prepare": "yarn build"
   },
   "dependencies": {
-    "@flowmap.gl/data": "^8.0.2"
+    "@flowmap.gl/data": "workspace:*"
   },
   "peerDependencies": {
     "@deck.gl/core": "^8.6.5",

--- a/packages/layers/src/FlowmapLayer.ts
+++ b/packages/layers/src/FlowmapLayer.ts
@@ -7,6 +7,7 @@ import {CompositeLayer} from '@deck.gl/core';
 import {ScatterplotLayer, TextLayer} from '@deck.gl/layers';
 import {
   FilterState,
+  FlowEndpointsInViewportMode,
   FlowLinesLayerAttributes,
   FlowmapAggregateAccessors,
   FlowmapData,
@@ -55,6 +56,7 @@ export type FlowmapLayerProps<
   colorScheme?: string | string[];
   highlightColor?: string | number[];
   maxTopFlowsDisplayNum?: number;
+  flowEndpointsInViewportMode?: FlowEndpointsInViewportMode;
   onHover?: (
     info: FlowmapLayerPickingInfo<L, F> | undefined,
     event: SourceEvent,
@@ -80,6 +82,7 @@ const PROPS_TO_CAUSE_LAYER_DATA_UPDATE: string[] = [
   'colorScheme',
   'highlightColor',
   'maxTopFlowsDisplayNum',
+  'flowEndpointsInViewportMode',
 ];
 
 enum HighlightType {
@@ -132,6 +135,7 @@ export default class FlowmapLayer<
     colorScheme: 'Teal',
     highlightColor: 'orange',
     maxTopFlowsDisplayNum: 5000,
+    flowEndpointsInViewportMode: 'any',
   };
   state: State<L, F> | undefined;
 
@@ -288,6 +292,7 @@ export default class FlowmapLayer<
       colorScheme,
       highlightColor,
       maxTopFlowsDisplayNum,
+      flowEndpointsInViewportMode,
     } = this.props;
     return {
       locationsEnabled,
@@ -305,6 +310,7 @@ export default class FlowmapLayer<
       colorScheme,
       highlightColor,
       maxTopFlowsDisplayNum,
+      flowEndpointsInViewportMode,
     };
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -591,7 +591,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@flowmap.gl/data@npm:^8.0.2, @flowmap.gl/data@workspace:*, @flowmap.gl/data@workspace:packages/data":
+"@flowmap.gl/data@workspace:*, @flowmap.gl/data@workspace:packages/data":
   version: 0.0.0-use.local
   resolution: "@flowmap.gl/data@workspace:packages/data"
   dependencies:
@@ -640,7 +640,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@flowmap.gl/layers@workspace:packages/layers"
   dependencies:
-    "@flowmap.gl/data": "npm:^8.0.2"
+    "@flowmap.gl/data": "workspace:*"
   peerDependencies:
     "@deck.gl/core": ^8.6.5
     "@deck.gl/layers": ^8.6.5


### PR DESCRIPTION
…ing (#61)

Add a new prop to `FlowmapLayer` that controls how flows are filtered based on viewport visibility. The prop accepts 'any' (default, current behaviour) or 'both' (stricter filtering requiring both endpoints in viewport).

- Add `FlowEndpointsInViewportMode` type to `FlowmapState`
- Update `getFlowsForFlowmapLayer` selector with conditional logic
- Add prop to `FlowmapLayer` with 'any' as default
- Add GUI dropdown control in example app
- Update API documentation